### PR TITLE
fix: Fix creating new user without hashing the password.

### DIFF
--- a/server/test_tracker/views/auth.py
+++ b/server/test_tracker/views/auth.py
@@ -40,7 +40,10 @@ class RegisterAPIView(GenericAPIView):
         """Method to register a new user"""
         serializer = self.get_serializer(data=request.data)
         if serializer.is_valid():
-            serializer.save()
+            password = make_password(request.data["password"])
+            if len(password) < 4:
+                return CustomResponse.bad_request(message="Password length should be at least 4 characters/numbers.")
+            serializer.save(password=password)
             return CustomResponse.success(
                 data=serializer.data,
                 message="User created successfully",


### PR DESCRIPTION
### Description

the user instance was created without hashing the password, so when login by the credentials we see `No active account found with the given credentials` because the system does compare the actual password string with the hashed password which will return a False

### Solution

Hashed the user password before saving it

### Changes

- Imported and used the `make_password` function to hash the user password
- Added a condition to validate the password length before hashing it

### Related issues

- https://github.com/codescalersinternships/test-tracker/issues/52