### PR TITLE
Update change settings end point

### DIFF
--- a/server/test_tracker/serializers/auth.py
+++ b/server/test_tracker/serializers/auth.py
@@ -106,7 +106,7 @@ class UpdateUserSettingsSerializer(ModelSerializer):
 
     class Meta:
         model = User
-        fields = ["first_name", "last_name", "phone", "password"]
+        fields = ["first_name", "last_name", "phone"]
 
 class GitHubRequestToGetAccessTokenSerializers(Serializer):
     client_id = CharField()

--- a/server/test_tracker/views/auth.py
+++ b/server/test_tracker/views/auth.py
@@ -154,10 +154,6 @@ class UpdateUserSettingsAPIView(GenericAPIView):
         """Update user settings"""
         user = get_user_by_id(request.user.id)
         serializer = self.get_serializer(user, data=request.data)
-        # if not request.data.get("password"):
-        #     request.data["password"] = user.password
-        # else:
-        #     request.data["password"] = make_password(request.data["password"])
         if serializer.is_valid():
             serializer.save()
             return CustomResponse.success(


### PR DESCRIPTION
### Description

Remove password attribute from the body of change settings request, because a new end point was already made to change the password only.

### Changes

- Remove password field from user serializer.
- Remove unused commented code.

### Related Issues

- https://github.com/codescalersinternships/test-tracker/issues/59